### PR TITLE
REFACTOR allow multiple words gif search

### DIFF
--- a/src/components/create.js
+++ b/src/components/create.js
@@ -39,7 +39,7 @@ export default class Create extends Component {
 
 		let post = [];
 
-		text = text.replace(/^gif\s+[^\s]+\s*/i, '');
+		text = text.replace(/^gif\s+(".*?"|[^\s]+)\s*/i, '');
 		if (text) {
 			post.push({ text, type });
 		}
@@ -68,7 +68,7 @@ export default class Create extends Component {
 	}
 
 	componentDidUpdate({ }, { text='' }) {
-		let p = text.match(/^gif\s+([^\s]+)/i);
+		let p = text.match(/^gif\s+(".*?"|[^\s]+)/i);
 		this.magicGif(p && p[1]);
 	}
 


### PR DESCRIPTION
Gif search engine can be made a bit more useful by allowing to search
for expressions containing multiple words. This is now possible using
quotes, like a google search for exact match.  `gif "foo fighters"` will
yield way more relevant results than `gif foo` or `gif fighters` :)

![nectarine](https://cloud.githubusercontent.com/assets/54562/12531191/b7472e6c-c1f4-11e5-8bc8-619e25504bb1.png)
