### PR TITLE
ADD friends list

### DIFF
--- a/src/components/connections.js
+++ b/src/components/connections.js
@@ -93,16 +93,31 @@ export class Connections extends Component {
 			connections.length = 50;
 		}
 
-		return (
-			<div class="explore view" onScroll={this.handleScroll}>
-				<div class="inner">
-					{ connections.map( connection => (
-						<Connection {...connection} meta={!this.explore} onClick={this.linkTo(`/profile/${encodeURIComponent(connection.id)}`)} />
-					)) }
-					{ !connections.length && loading ? <LoadingScreen overlay /> : null }
+		if ( connections.length ){
+			return (
+				<div class="explore view" onScroll={this.handleScroll}>
+					<div class="inner">
+						{ connections.map( connection => (
+							<Connection {...connection} meta={!this.explore} onClick={this.linkTo(`/profile/${encodeURIComponent(connection.id)}`)} />
+						)) }
+						{ !connections.length && loading ? <LoadingScreen overlay /> : null }
+					</div>
 				</div>
-			</div>
-		);
+			);
+		}
+
+		else {
+			return (
+				<div class="explore view">
+					<div class="inner">
+						<div class="nothing">
+							<p>Nothing new here.</p>
+							<p>Want to see <Link href="/friends">older posts from friends?</Link></p>
+						</div>
+					</div>
+				</div>
+			);
+		}
 	}
 }
 

--- a/src/components/friend.js
+++ b/src/components/friend.js
@@ -1,0 +1,28 @@
+import { h, Component } from 'preact';
+import { bind } from 'decko';
+import { emit } from '../pubsub';
+
+export default class Friends extends Component {
+	@bind
+	goAuthor(e) {
+		let { id } = this.props;
+		emit('go', { url:`/profile/${encodeURIComponent(id)}` });
+	}
+
+	render({ avatarSrc, bio, displayName, name, unreadPostCount }){
+		let border = unreadPostCount ? '#25d87a' : '#fff';
+
+		return (
+			<div class="friend mdl-grid" onClick={this.goAuthor}>
+				<div class="mdl-cell mdl-cell--2-col mdl-cell--1-col-phone mdl-cell--1-col-tablet">
+					<div class="avatar" style={`background-image: url(${avatarSrc}); border: 3px solid ${border}`} />
+				</div>
+				<div class="mdl-cell mdl-cell--10-col mdl-cell--3-col-phone mdl-cell--5-col-tablet">
+					<h2>{displayName} <em>@{name}</em></h2>
+					<footer>{bio}</footer>
+				</div>
+			</div>
+		);
+	}
+}
+

--- a/src/components/friends.js
+++ b/src/components/friends.js
@@ -1,0 +1,45 @@
+import { h, Component } from 'preact';
+import Friend from './friend';
+
+export default class Friends extends Component {
+	state = {
+		connections: [],
+	};
+
+	componentDidMount(){
+		peach.updateConnections();
+		this.setState({ connections: peach.store.getState().connections || [] });
+	}
+
+	render({}, { connections }){
+		let content;
+
+		if ( connections.length ){
+			return (
+				<div class="friends-list view view-scroll">
+					<div class="friends">
+						<div class="friends-inner">{
+							connections.map( friend => <Friend {...friend} /> )
+						}</div>
+					</div>
+				</div>
+			);
+		}
+
+		else {
+			return (
+				<div class="explore view">
+					<div class="inner">
+						<div class="nothing">
+							<p>Sorry, no one here yet.</p>
+							<p>
+								You seem to have no contact yet in Peach network. Hit the "add friend"
+								button on top left and start adding some!
+							</p>
+						</div>
+					</div>
+				</div>
+			);
+		}
+	}
+}

--- a/src/components/main.js
+++ b/src/components/main.js
@@ -4,6 +4,7 @@ import Router, { route } from 'preact-router';
 import { bind, debounce } from 'decko';
 import Stream from './stream';
 import { Connections, ExploreConnections } from './connections';
+import Friends from './friends';
 import Profile from './profile';
 import Notifications from './notifications';
 import Settings from './settings';
@@ -46,6 +47,7 @@ export default class App extends Component {
 			<Layout.Content id="content" onScroll={this.handleScroll}>
 				<Router onChange={::this.onRoute}>
 					<Connections path="/" />
+					<Friends path="/friends" />
 					<ExploreConnections path="/explore" />
 					<Stream path="/stream" />
 					<Profile path="/profile" id="me" />

--- a/src/components/sidebar.js
+++ b/src/components/sidebar.js
@@ -62,6 +62,7 @@ export default class Sidebar extends Component {
 				</Layout.Title>
 				<Navigation>
 					<Link href="/" route={this.go}>Home</Link>
+					<Link href="/friends" route={this.go}>Friends List</Link>
 					<Link href="/explore" route={this.go}>Explore <em>Friends of Friends</em></Link>
 					<Link href="/profile" route={this.go}>My Profile</Link>
 					<Link href="/stream" route={this.go}>Stream</Link>

--- a/src/style/profile.less
+++ b/src/style/profile.less
@@ -1,5 +1,6 @@
 @import 'helpers';
 
+.friends-list,
 .profile,
 .stream {
 
@@ -102,6 +103,7 @@
 }
 
 
+.friend,
 .post {
 	margin: 10px;
 	padding: 30px 10px 10px;
@@ -137,5 +139,29 @@
 		background-repeat: no-repeat;
 		border-radius: 50%;
 		cursor: pointer;
+	}
+}
+
+.friend {
+	cursor: pointer;
+
+	.avatar {
+		float: none;
+	}
+
+	h2 {
+		font-size: 150%;
+		margin: 0 0 10px;
+		line-height: 1em;
+
+		em {
+			font-size: 70%;
+			color: #777;
+			font-style: normal;
+		}
+
+		footer {
+			color: #555;
+		}
 	}
 }


### PR DESCRIPTION
It may be a bit annoying not to be able to access a friend list. For
example, trying to retrieve a previous post or see if there are any new
comments on them is almost impossible (you have to wait for the same
person to post something new). Also, the home screen being blank most of
the time can be surprising for user.

To fix this, a Friend list has been implemented.
- it can be accessed from the menu bar
- it lists people you follow
- if there is nothing to show on home screen, a link will offer to go to
  friend list to see older posts

When a friend has unread posts, you will see a green border around their
avatar.

![friend-list-1](https://cloud.githubusercontent.com/assets/54562/12531894/6366dd6c-c206-11e5-9f40-c5fa958f2e44.png)

![friend-list-2](https://cloud.githubusercontent.com/assets/54562/12531896/6baf51c0-c206-11e5-89df-9922fef219ff.png)

![friend-list-3](https://cloud.githubusercontent.com/assets/54562/12531899/72259aa0-c206-11e5-9c80-fa5248a9af5e.png)
