### PR TITLE
fix: Set inject to false on html-webpack-plugin config

### DIFF
--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -62,6 +62,7 @@ module.exports = {
 		}),
 		new HtmlWebpackPlugin({
 			template: './index.html',
+			inject: false,
 			minify: {
 				collapseWhitespace: true,
 				removeComments: true


### PR DESCRIPTION
Prevents webpack from adding bundled css and js twice